### PR TITLE
Add bootstrap.php file to phpunit configuration.

### DIFF
--- a/test/phpunit.xml
+++ b/test/phpunit.xml
@@ -5,6 +5,7 @@
   convertErrorsToExceptions="true"
   convertNoticesToExceptions="true"
   convertWarningsToExceptions="true"
+  bootstrap="bootstrap.php"
 >
   <filter>
     <whitelist>


### PR DESCRIPTION
This prevents unnecessary surprises when trying to run the tests from a console.
