### PR TITLE
Add channel to logging.

### DIFF
--- a/src/mg/PAGI/Client/Impl/ClientImpl.php
+++ b/src/mg/PAGI/Client/Impl/ClientImpl.php
@@ -80,7 +80,8 @@ class ClientImpl extends AbstractClient
     protected function send($text)
     {
         if ($this->_logger->isDebugEnabled()) {
-            $this->_logger->debug('Sending: ' . $text);
+            $channel = $this->getChannelVariables()->getChannel();
+            $this->_logger->debug('['.$channel.'] Sending: '.$text);
         }
         $text .= "\n";
         $len = strlen($text);
@@ -120,7 +121,15 @@ class ClientImpl extends AbstractClient
             $this->readEnvironmentVariable($line);
         }
         if ($this->_logger->isDebugEnabled()) {
-            $this->_logger->debug(print_r($this->_variables, true));
+            $channel = $this->getChannelVariables()->getChannel();
+            $message = '['.$channel.'] === BEGIN AGI VARIABLES ===' . PHP_EOL;
+
+            foreach($this->_variables as $name => $value) {
+                $message .= '['.$channel.'] '.$name.' => '.$value.PHP_EOL;
+            }
+
+            $message .= '['.$channel.'] === END AGI VARIABLES ==='.PHP_EOL;
+            $this->_logger->debug($message);
         }
     }
 
@@ -154,7 +163,11 @@ class ClientImpl extends AbstractClient
         }
         $line = substr($line, 0, -1);
         if ($this->_logger->isDebugEnabled()) {
-            $this->_logger->debug('Read: ' . $line);
+            $channel = 'uninitialized';
+            if (isset($this->_variables['channel'])) {
+                $channel = $this->_variables['channel'];
+            }
+            $this->_logger->debug('['.$channel.'] Read: '.$line);
         }
         return $line;
     }


### PR DESCRIPTION
Hi Marcelo,

In the process of creating a replacement voice stack based on Asterisk,
we found that we needed to add some functionality to PAGI. This is the
first of a series of PRs aimed at mainlining these changes.

This PR prefixes the Channel name to the logs. By explicitly logging
the channel, it becomes much easier to track a single call. This is
especially relevant with a lot of simultaneous calls, which we deal
with.

In the current implementation, as long as the channel name is not known,
it defaults to 'uninitialized'. This should only happen in the ::read()
method, for the first couple of AGI variables. That is somewhat annoying,
annoying but the payoff to have all the 'real' agi commands prefixed by
the channnel name is worth it.

In ClientImpl::read() we use ::_variables['channel'] instead of the
Channel Variables Facade. This is necessary, because if we use that
facade in the read() method, the facade is created before the channel
variables are received. When that happens, no channel variables will be
available.
