### PR TITLE
Support for agi network variables (with tests)

### DIFF
--- a/doc/PAGI-CallSpool-CallFile.md
+++ b/doc/PAGI-CallSpool-CallFile.md
@@ -512,7 +512,7 @@ file_get_contents() or similar).&lt;/p&gt;
 
 ### __construct
 
-    void PAGI\CallSpool\CallFile::__construct(\PAGI\DialDescriptor\DialDescriptor $dialDescriptor)
+    void PAGI\CallSpool\CallFile::__construct(\PAGI\CallSpool\PAGI\DialDescriptor\DialDescriptor $dialDescriptor)
 
 Constructor.
 
@@ -522,6 +522,6 @@ Constructor.
 
 
 #### Arguments
-* $dialDescriptor **[PAGI\DialDescriptor\DialDescriptor](PAGI-DialDescriptor-DialDescriptor.md)**
+* $dialDescriptor **PAGI\CallSpool\PAGI\DialDescriptor\DialDescriptor** - &lt;p&gt;dial descriptor&lt;/p&gt;
 
 

--- a/doc/PAGI-ChannelVariables-IChannelVariables.md
+++ b/doc/PAGI-ChannelVariables-IChannelVariables.md
@@ -463,3 +463,29 @@ Uses environment variable AST_RUN_DIR.
 
 
 
+
+### getNetworkScript
+
+    string PAGI\ChannelVariables\IChannelVariables::getNetworkScript()
+
+Returns agi_network_script.
+
+
+
+* Visibility: **public**
+
+
+
+
+### getNetwork
+
+    string PAGI\ChannelVariables\IChannelVariables::getNetwork()
+
+Returns agi_network.
+
+
+
+* Visibility: **public**
+
+
+

--- a/doc/PAGI-ChannelVariables-Impl-ChannelVariablesFacade.md
+++ b/doc/PAGI-ChannelVariables-Impl-ChannelVariablesFacade.md
@@ -554,3 +554,31 @@ Constructor.
 * $arguments **array&lt;mixed,string&gt;** - &lt;p&gt;AGI arguments given by asterisk (agi_arg_N).&lt;/p&gt;
 
 
+
+### getNetworkScript
+
+    string PAGI\ChannelVariables\IChannelVariables::getNetworkScript()
+
+Returns agi_network_script.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAGI\ChannelVariables\IChannelVariables](PAGI-ChannelVariables-IChannelVariables.md)
+
+
+
+
+### getNetwork
+
+    string PAGI\ChannelVariables\IChannelVariables::getNetwork()
+
+Returns agi_network.
+
+
+
+* Visibility: **public**
+* This method is defined by [PAGI\ChannelVariables\IChannelVariables](PAGI-ChannelVariables-IChannelVariables.md)
+
+
+

--- a/doc/PAGI-Client-AbstractClient.md
+++ b/doc/PAGI-Client-AbstractClient.md
@@ -20,7 +20,7 @@ Properties
 
 ### $logger
 
-    protected \PAGI\Client\Logger $logger
+    protected \Psr\Log\LoggerInterface $logger
 
 PSR-3 logger.
 

--- a/doc/PAGI-Client-Impl-ClientImpl.md
+++ b/doc/PAGI-Client-Impl-ClientImpl.md
@@ -54,7 +54,7 @@ AGI output
 
 ### $logger
 
-    protected \PAGI\Client\Logger $logger
+    protected \Psr\Log\LoggerInterface $logger
 
 PSR-3 logger.
 

--- a/doc/PAGI-Client-Impl-MockedClientImpl.md
+++ b/doc/PAGI-Client-Impl-MockedClientImpl.md
@@ -42,7 +42,7 @@ Mocked result strings.
 
 ### $logger
 
-    protected \PAGI\Client\Logger $logger
+    protected \Psr\Log\LoggerInterface $logger
 
 PSR-3 logger.
 

--- a/doc/PAGI-Node-MockedNode.md
+++ b/doc/PAGI-Node-MockedNode.md
@@ -1500,7 +1500,7 @@ Returns the kind of digit entered by the user, CANCEL, END, NORMAL.
 
 ### acceptInput
 
-    void PAGI\Node\Node::acceptInput($digit)
+    void PAGI\Node\Node::acceptInput(\PAGI\Node\@param $digit)
 
 Process a single digit input by the user. Changes the node state
 according to the digit entered (CANCEL, COMPLETE).
@@ -1512,7 +1512,7 @@ according to the digit entered (CANCEL, COMPLETE).
 
 
 #### Arguments
-* $digit **mixed**
+* $digit **PAGI\Node\@param** - &lt;p&gt;string $digit A single character, one of the DTMF_* constants.&lt;/p&gt;
 
 
 

--- a/doc/PAGI-Node-Node.md
+++ b/doc/PAGI-Node-Node.md
@@ -1119,7 +1119,7 @@ Returns the kind of digit entered by the user, CANCEL, END, NORMAL.
 
 ### acceptInput
 
-    void PAGI\Node\Node::acceptInput($digit)
+    void PAGI\Node\Node::acceptInput(\PAGI\Node\@param $digit)
 
 Process a single digit input by the user. Changes the node state
 according to the digit entered (CANCEL, COMPLETE).
@@ -1130,7 +1130,7 @@ according to the digit entered (CANCEL, COMPLETE).
 
 
 #### Arguments
-* $digit **mixed**
+* $digit **PAGI\Node\@param** - &lt;p&gt;string $digit A single character, one of the DTMF_* constants.&lt;/p&gt;
 
 
 

--- a/src/PAGI/Application/PAGILauncher.php
+++ b/src/PAGI/Application/PAGILauncher.php
@@ -31,14 +31,12 @@
  * limitations under the License.
  *
  */
-use PAGI\Application\Exception\InvalidApplicationException;
-use PAGI\Application\PAGIApplication;
 
 $appName = getenv('PAGIApplication');
 $bootstrap = getenv('PAGIBootstrap');
 $myApp = '';
-try {
 
+try {
     include_once $bootstrap;
     if (!class_exists($appName, true)) {
         throw new \Exception($appName . ' is not loaded');

--- a/src/PAGI/ChannelVariables/IChannelVariables.php
+++ b/src/PAGI/ChannelVariables/IChannelVariables.php
@@ -291,4 +291,18 @@ interface IChannelVariables
      * @return string
      */
     public function getDirectoryRun();
+
+    /**
+     * Returns agi_network_script.
+     *
+     * @return string
+     */
+    public function getNetworkScript();
+
+    /**
+     * Returns agi_network.
+     *
+     * @return string
+     */
+    public function getNetwork();
 }

--- a/src/PAGI/ChannelVariables/Impl/ChannelVariablesFacade.php
+++ b/src/PAGI/ChannelVariables/Impl/ChannelVariablesFacade.php
@@ -394,4 +394,22 @@ class ChannelVariablesFacade implements IChannelVariables
         $this->variables = $variables;
         $this->arguments = $arguments;
     }
+
+    /**
+     * (non-PHPdoc)
+     * @see PAGI\ChannelVariables.IChannelVariables::getNetworkScript()
+     */
+    public function getNetworkScript()
+    {
+        return $this->getAGIVariable('network_script');
+    }
+
+    /**
+     * (non-PHPdoc)
+     * @see PAGI\ChannelVariables.IChannelVariables::getNetwork()
+     */
+    public function getNetwork()
+    {
+        return $this->getAGIVariable('network');
+    }
 }

--- a/src/PAGI/Client/AbstractClient.php
+++ b/src/PAGI/Client/AbstractClient.php
@@ -66,7 +66,7 @@ abstract class AbstractClient implements IClient
 {
     /**
      * PSR-3 logger.
-     * @var Logger
+     * @var LoggerInterface
      */
     protected $logger;
 
@@ -573,7 +573,6 @@ abstract class AbstractClient implements IClient
                 array($priority, str_replace('"', '\\"', $line))
             );
         }
-
     }
 
     /**
@@ -888,7 +887,7 @@ abstract class AbstractClient implements IClient
     /**
      * Sets the logger implementation.
      *
-     * @param Psr\Log\LoggerInterface $logger The PSR3-Logger
+     * @param LoggerInterface $logger The PSR3-Logger
      *
      * @return void
      */

--- a/src/PAGI/Client/Impl/MockedClientImpl.php
+++ b/src/PAGI/Client/Impl/MockedClientImpl.php
@@ -124,7 +124,7 @@ class MockedClientImpl extends AbstractClient
         $count = count($args);
         for ($i = 0; $i < $count; $i++) {
             if (!isset($arguments[$i])) {
-                throw new MockedException("Missing argument number " . $i + 1);
+                throw new MockedException("Missing argument number " . ($i + 1));
             }
             $arg = $arguments[$i];
             if ($arg !== $args[$i]) {

--- a/src/PAGI/Node/Node.php
+++ b/src/PAGI/Node/Node.php
@@ -1184,7 +1184,6 @@ class Node
      */
     protected function beforeOnValidInput()
     {
-
     }
 
     /**
@@ -1194,7 +1193,6 @@ class Node
      */
     protected function beforeOnInputFailed()
     {
-
     }
 
     /**

--- a/test/channelvars/Test_ChannelVariables.php
+++ b/test/channelvars/Test_ChannelVariables.php
@@ -104,6 +104,8 @@ class Test_ChannelVariables extends \PHPUnit_Framework_TestCase
             $vars->getArguments()
         );
         $this->assertFalse($vars->getArgument(4));
+        $this->assertEquals($vars->getNetwork(), 'yes');
+        $this->assertEquals($vars->getNetworkScript(), 'ScriptName');
         $refObject = new \ReflectionObject($vars);
         $refMethod = $refObject->getMethod('getAGIVariable');
         $refMethod->setAccessible(true);

--- a/test/client/Test_Client.php
+++ b/test/client/Test_Client.php
@@ -69,6 +69,8 @@ namespace {
 		'agi_enhanced:0.0',
 		'agi_accountcode:123',
 		'agi_threadid:1105672528',
+        'agi_network:yes',
+        'agi_network_script:ScriptName',
         ''
     );
 


### PR DESCRIPTION
Added support for AGI `network` and `network_script` variables.

Closes #39. This includes unit tests.